### PR TITLE
Quote dirname arguments - fixes the menu script creation 

### DIFF
--- a/joystick_selection.sh
+++ b/joystick_selection.sh
@@ -66,7 +66,7 @@ fi
 # checking for runcommand-menu feature
 jsonmenu="/opt/retropie/configs/all/runcommand-menu/select joystick.sh"
 if [[ ! -s "$jsonmenu" ]]; then
-    mkdir -p "$(dirname $jsonmenu)"
+    mkdir -p "$(dirname "$jsonmenu")"
     cat > "$jsonmenu" << _EoF_
 system="\$1"
 game="\$(basename "\$3")"


### PR DESCRIPTION
I just tested the script on the Raspbian Stretch RP image and I noticed that `dirname` will produce 2 lines when called to get the `runcommand-menu` folder:
```
$ jsonmenu="/opt/retropie/configs/all/runcommand-menu/select joystick.sh"
$ dirname $jsonmenu
/opt/retropie/configs/all/runcommand-menu
.

$
```
As a side effect, the folder that gets created has a wonky name
`/opt/retropie/configs/all/runcommand-menu..`.

If `$jsonmenu` is properly quoted, this doesn't happen.