### PR TITLE
Find RetroPie-Setup folder with locate.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 user="$SUDO_USER"
 [[ -z "$user" ]] && user="$(id -un)"
 home="$(eval echo ~$user)"
-readonly RP_SETUP_DIR="$home/RetroPie-Setup"
+readonly RP_SETUP_DIR=$(locate -b RetroPie-Setup)
 readonly JS_SCRIPTMODULE_FULL="$RP_SETUP_DIR/scriptmodules/supplementary/joystick-selection.sh"
 readonly JS_SCRIPTMODULE_URL="https://raw.githubusercontent.com/meleu/RetroPie-joystick-selection/master/js-scriptmodule.sh"
 readonly JS_SCRIPTMODULE="$(basename "${JS_SCRIPTMODULE_FULL%.*}")"


### PR DESCRIPTION
Capture the RetroPie-Setup folder with 'locate', therefore, it does not matter the position used to install the retropie.